### PR TITLE
Update option_lists.rst

### DIFF
--- a/provisioning/library/option_lists.rst
+++ b/provisioning/library/option_lists.rst
@@ -442,7 +442,7 @@ Populating LDAP-type Option Lists requires knowledge of LDAP query syntax. This 
     }
 
     a['value'] = row.sAMAccountName;
-    results.push;
+    results.push(a);
 
   }
 


### PR DESCRIPTION
Fixed an error in the example translation script which will convert returned LDAP objects into a list of name:value pairs you can work with in Morpheus. I rebuilt the example and without the fix you only get "null" as output.
It's a tiny change, but a start :)