### PR TITLE
corrects provisioning.rst by removing misplaced environment and licenses includes

### DIFF
--- a/administration/settings/provisioning.rst
+++ b/administration/settings/provisioning.rst
@@ -43,9 +43,6 @@ PXE Boot Settings
 Default Root Password
   Enter the default password to be set for Root during PXE Boots.
 
-.. include:: environments.rst
-.. include:: licenses.rst
-
 App Blueprint Settings
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
These appear to be orphaned and included in error here. They appear correctly, later in the settings page.