### PR TITLE
docs: add HVMCLI command-line reference under Tools

### DIFF
--- a/tools/hvmcli/cluster.rst
+++ b/tools/hvmcli/cluster.rst
@@ -1,0 +1,44 @@
+cluster
+-------
+
+Show cluster state and quorum information.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``status``
+     - Display cluster status and quorum information
+   * - ``nodes``
+     - List cluster nodes with status and role
+
+cluster status
+``````````````
+
+Display the current cluster status including quorum state, active nodes, and health.
+
+.. code-block:: bash
+
+   sudo hvmcli cluster status
+
+.. code-block:: bash
+
+   sudo hvmcli cluster status --json
+
+cluster nodes
+`````````````
+
+List all nodes in the cluster with their current status and role.
+
+.. code-block:: bash
+
+   sudo hvmcli cluster nodes --list
+
+Options:
+
+- ``--list`` — Display nodes in list format

--- a/tools/hvmcli/deploy.rst
+++ b/tools/hvmcli/deploy.rst
@@ -1,0 +1,112 @@
+deploy
+------
+
+Deploy VME (VM Essentials) Manager or Worker virtual machines on the HVM host.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``manager``
+     - Deploy, manage, or check status of the VME Manager VM
+   * - ``worker``
+     - Deploy, manage, or check status of a VME Worker VM
+
+deploy manager
+``````````````
+
+Deploy or manage the VME Manager appliance virtual machine.
+
+**Deploy a new Manager VM:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy manager \
+     --ip 10.1.1.100 \
+     --netmask 255.255.255.0 \
+     --gateway 10.1.1.1 \
+     --hostname vme-mgr \
+     --image file:///mnt/iso/morpheus.qcow2 \
+     --interface enp3s0 \
+     --admin-user morphadmin \
+     --admin-password-stdin
+
+Options:
+
+- ``--ip <address>`` — Static IP address for the Manager VM
+- ``--netmask <mask>`` — Subnet mask
+- ``--gateway <address>`` — Default gateway
+- ``--hostname <name>`` — Hostname for the VM
+- ``--image <uri>`` — Path or URL to the QCOW2 image (``file://`` or ``http://``)
+- ``--interface <nic>`` — Host interface for the VM network
+- ``--admin-user <username>`` — Administrator username for the appliance
+- ``--admin-password-stdin`` — Read admin password from stdin (secure, no shell history)
+
+**Run pre-deployment checks:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy manager precheck \
+     --ip 10.1.1.100 \
+     --interface enp3s0 \
+     --image file:///mnt/iso/morpheus.qcow2 \
+     --json
+
+**Check Manager VM status:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy manager status
+   sudo hvmcli deploy manager status --json
+
+**View Manager deployment logs:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy manager logs
+   sudo hvmcli deploy manager logs --lines 100 --diagnostics
+
+Options:
+
+- ``--lines <n>`` — Number of log lines to display
+- ``--diagnostics`` — Include diagnostic information
+
+deploy worker
+`````````````
+
+Deploy or manage a VME Worker virtual machine.
+
+**Deploy a new Worker VM:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy worker \
+     --ip 10.1.1.110 \
+     --netmask 255.255.255.0 \
+     --gateway 10.1.1.1 \
+     --hostname vme-wkr1 \
+     --image file:///mnt/iso/morpheus.qcow2 \
+     --interface enp3s0 \
+     --worker-url https://10.1.1.100 \
+     --worker-key abc123 \
+     --apikey def456 \
+     --admin-password-stdin
+
+Additional options for Worker:
+
+- ``--worker-url <url>`` — URL of the Manager VM to register with
+- ``--worker-key <key>`` — Worker registration key from the Manager
+- ``--apikey <key>`` — API key for Manager authentication
+
+**Check Worker VM status:**
+
+.. code-block:: bash
+
+   sudo hvmcli deploy worker status --json
+
+.. tip:: Always run ``deploy manager precheck`` before deploying to validate that network connectivity, image accessibility, and host resources are adequate.

--- a/tools/hvmcli/getting_started.rst
+++ b/tools/hvmcli/getting_started.rst
@@ -1,0 +1,115 @@
+Getting Started
+---------------
+
+Installation
+````````````
+
+``hvmcli`` is pre-installed on all HPE HVM hosts. No manual installation is required.
+
+To verify the installed version:
+
+.. code-block:: bash
+
+   sudo hvmcli version
+
+.. code-block:: text
+
+   hvmcli 1.0.0 (build 20260719)
+
+Usage
+`````
+
+The general syntax for ``hvmcli`` commands is:
+
+.. code-block:: bash
+
+   sudo hvmcli <namespace> <command> [options]
+
+For example:
+
+.. code-block:: bash
+
+   sudo hvmcli vm list
+   sudo hvmcli node list
+   sudo hvmcli virtswitch list
+
+To get help on any namespace:
+
+.. code-block:: bash
+
+   sudo hvmcli <namespace> help
+
+Global Options
+``````````````
+
+The following options are available for all commands:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Option
+     - Description
+   * - ``--json``
+     - Output results in JSON format. Useful for scripting and automation.
+   * - ``--debug``
+     - Enable verbose debug logging to stderr for troubleshooting.
+   * - ``--help``
+     - Show help for the current namespace or command.
+
+JSON Output
+```````````
+
+All commands support ``--json`` output for automation and integration with other tools. JSON responses follow a standard envelope format:
+
+.. code-block:: json
+
+   {
+     "errorCode": 0,
+     "messages": "",
+     "data": { ... }
+   }
+
+- ``errorCode``: ``0`` indicates success, non-zero indicates an error.
+- ``messages``: Empty on success, contains error description on failure.
+- ``data``: The command-specific response payload.
+
+Namespaces
+``````````
+
+``hvmcli`` is organized into the following namespaces:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Namespace
+     - Description
+   * - ``vm``
+     - Manage virtual machines (list, start, stop, restart)
+   * - ``node``
+     - Manage the physical node (configuration, backup, reboot)
+   * - ``interfaces``
+     - List network interfaces and manage SR-IOV virtual functions
+   * - ``virtswitch``
+     - Manage Virtual Switches (create, edit, delete, import)
+   * - ``network``
+     - List virtual networks and run connectivity tests
+   * - ``storage``
+     - Manage storage pools, iSCSI, Fibre Channel, and multipath
+   * - ``cluster``
+     - Show cluster state and quorum information
+   * - ``hardware``
+     - Inspect host hardware (CPU, memory, PCI, boot volume, IPMI)
+   * - ``software``
+     - Inspect installed packages and manage OS updates
+   * - ``logs``
+     - View node, cluster, and agent logs
+   * - ``health``
+     - Run host readiness and health checks
+   * - ``top``
+     - Real-time host and VM resource monitoring
+   * - ``security``
+     - Security compliance operations (FIPS 140)
+   * - ``deploy``
+     - Deploy VME Manager or Worker virtual machines

--- a/tools/hvmcli/hardware.rst
+++ b/tools/hvmcli/hardware.rst
@@ -1,0 +1,128 @@
+hardware
+--------
+
+Inspect host hardware inventory and platform telemetry.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``cpu``
+     - Show CPU topology, model, cores, and threads
+   * - ``memory``
+     - Show memory modules, total capacity, and speed
+   * - ``pci``
+     - List PCI devices (network adapters, GPUs, storage controllers)
+   * - ``bootvolume``
+     - Show boot volume details and mount points
+   * - ``ipmi``
+     - Show IPMI/BMC sensor readings (requires ipmitool)
+
+hardware cpu
+````````````
+
+Display CPU architecture, topology, and virtualization details.
+
+.. code-block:: bash
+
+   sudo hvmcli hardware cpu list
+
+.. code-block:: text
+
+   Architecture           x86_64
+     CPU(s)                 64
+     Thread(s) per core     2
+     Core(s) per socket     16
+     Socket(s)              2
+     Model Name             AMD EPYC 9334 32-Core Processor
+     Vendor ID              AuthenticAMD
+     Virtualization         AMD-V
+     Logical CPU Threads    64
+     Hyperthreading Active  yes
+     Physical CPU Cores     32
+
+hardware memory
+```````````````
+
+Display memory capacity, usage, NUMA, and HugePages information.
+
+.. code-block:: bash
+
+   sudo hvmcli hardware memory list
+
+.. code-block:: text
+
+     Physical Memory   512.00 GiB
+     Reliable Memory   512.00 GiB
+     NUMA Node Count   2
+     Total Memory      512.00 GiB
+     Used Memory       128.50 GiB
+     Available Memory  383.50 GiB
+     Free Memory       256.00 GiB
+     Swap Total        4.00 GiB
+     Swap Free         4.00 GiB
+     HugePages Total   0
+     HugePages Free    0
+     HugePage Size     2.00 MiB
+
+hardware pci
+````````````
+
+List all PCI devices including network adapters, GPUs, and storage controllers.
+
+.. code-block:: bash
+
+   sudo hvmcli hardware pci list
+
+.. code-block:: text
+
+   Slot     Class                    Device                                               Vendor:Device
+   -------  -----------------------  ---------------------------------------------------  -------------
+   03:00.0  Ethernet controller      Mellanox ConnectX-6 Dx 25GbE Dual Port SFP28         15b3:101d
+   04:00.0  Ethernet controller      Mellanox ConnectX-6 Dx 25GbE Dual Port SFP28         15b3:101d
+   41:00.0  RAID bus controller      HPE Smart Array P408i-a SR Gen10                     9005:028f
+   ...
+
+hardware bootvolume
+```````````````````
+
+Show boot volume details including disk type, filesystem, and size.
+
+.. code-block:: bash
+
+   sudo hvmcli hardware bootvolume list
+
+.. code-block:: text
+
+     Root Device             /dev/ubuntu--vg-ubuntu--lv
+     Boot Device Identifier  /dev/sda2
+     Boot Device Type        part
+     Root Filesystem         ext4
+     Root Type               lvm
+     Root Size               480G
+     Boot Device             /dev/sda2
+     Boot Filesystem         ext4
+     Boot Size               2G
+     Boot Disk               /dev/sda
+     Boot Disk Size          480G
+     Boot Disk Model         MO000480JWTBR
+     Boot Disk Serial        PHYG123456
+     Boot Disk Transport     sata
+     Boot Disk Rotational    no
+     Boot Disk Read-Only     no
+
+hardware ipmi
+`````````````
+
+Show IPMI/BMC sensor readings for platform telemetry.
+
+.. code-block:: bash
+
+   sudo hvmcli hardware ipmi
+
+.. note:: Requires ``ipmitool`` to be installed on the host. Only available on physical servers with a BMC/iLO.

--- a/tools/hvmcli/health.rst
+++ b/tools/hvmcli/health.rst
@@ -1,0 +1,58 @@
+health
+------
+
+Run host readiness and health checks.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``check``
+     - Run host readiness checks
+   * - ``watch``
+     - Continuously run health checks at a polling interval
+
+health check
+````````````
+
+Run a comprehensive set of host readiness checks including cluster state, VM health, NTP sync, resource availability, gateway reachability, agent status, uplink state, iSCSI connectivity, and multipath configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli health check
+
+.. code-block:: bash
+
+   sudo hvmcli health check --json
+
+The check covers:
+
+- **Cluster** — Cluster membership and quorum state
+- **VMs** — VM health and consistency
+- **NTP** — Time synchronization status
+- **Resources** — CPU, memory, and disk availability
+- **Gateway** — Network gateway reachability
+- **Agent** — Morpheus agent connectivity
+- **Uplinks** — Physical NIC link state
+- **iSCSI** — iSCSI session health (if configured)
+- **Multipath** — Multipath path availability (if configured)
+
+health watch
+````````````
+
+Continuously run health checks at a specified interval.
+
+.. code-block:: bash
+
+   sudo hvmcli health watch --interval 30
+
+Options:
+
+- ``--interval <seconds>`` — Polling interval in seconds (default: 60)
+
+.. tip:: Use ``health watch`` during maintenance operations to continuously monitor host health and detect issues early.

--- a/tools/hvmcli/hvmcli.rst
+++ b/tools/hvmcli/hvmcli.rst
@@ -1,0 +1,27 @@
+HVMCLI
+======
+
+.. versionadded:: 9.1
+
+``hvmcli`` is the command-line interface for managing HPE HVM hypervisor hosts. It provides a comprehensive set of tools for managing virtual machines, networking, storage, hardware inspection, cluster operations, and system maintenance directly from the host console.
+
+``hvmcli`` is pre-installed on all HVM hosts and requires ``sudo`` privileges to execute most commands.
+
+.. toctree::
+   :maxdepth: 2
+
+   getting_started
+   vm
+   node
+   interfaces
+   virtswitch
+   network
+   storage
+   cluster
+   hardware
+   software
+   logs
+   health
+   top
+   security
+   deploy

--- a/tools/hvmcli/interfaces.rst
+++ b/tools/hvmcli/interfaces.rst
@@ -1,0 +1,85 @@
+interfaces
+----------
+
+List network interfaces and manage SR-IOV virtual functions.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List network interfaces with optional filtering
+   * - ``vf``
+     - Manage SR-IOV virtual functions (list, create, delete, set)
+
+interfaces list
+```````````````
+
+List all network interfaces on the host. By default shows all interfaces.
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces list
+
+.. code-block:: text
+
+   Interface  Type      MAC                Speed    Link  Driver       Firmware  SR-IOV         Max VFs  Configured VFs  Manufacturer  LLDP
+   ---------  --------  -----------------  -------  ----  ----------   --------  -------------  -------  --------------  ------------  ----
+   ens1f0np0  Ethernet  b4:96:91:a0:12:34  25Gbps   up    mlx5_core   22.39     supported      64       0               Mellanox      sw1/Eth1/1
+   ens2f0np0  Ethernet  b4:96:91:a0:12:35  25Gbps   up    mlx5_core   22.39     supported      64       0               Mellanox      sw1/Eth1/2
+   enp3s0     Ethernet  52:54:00:86:9e:12  -        up    virtio_net  -         not supported  0        0               Red Hat       -
+
+Use ``--filter`` to show specific interface types:
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces list --filter ethernet
+   sudo hvmcli interfaces list --filter fc
+   sudo hvmcli interfaces list --filter network
+   sudo hvmcli interfaces list --filter data
+   sudo hvmcli interfaces list --filter sdn
+
+Filter options:
+
+- ``ethernet`` — Physical Ethernet interfaces only
+- ``fc`` — Fibre Channel HBAs only
+- ``network`` — Interfaces that are part of a Virtual Switch network
+- ``general`` — General purpose interfaces
+- ``data`` — Data network interfaces
+- ``sdn`` — SDN network interfaces
+
+interfaces vf
+`````````````
+
+Manage SR-IOV Virtual Functions (VFs) on supported interfaces.
+
+**List VFs on an interface:**
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces vf list --interface ens1f0np0
+
+**Create VFs on an interface:**
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces vf create --interface ens1f0np0 --count 4
+
+**Delete VFs from an interface:**
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces vf delete --interface ens1f0np0
+
+**Set VF properties:**
+
+.. code-block:: bash
+
+   sudo hvmcli interfaces vf set --interface ens1f0np0 --vf 0 --mac 00:11:22:33:44:55
+
+.. note:: SR-IOV must be enabled in the BIOS and the NIC must support virtual functions. Use ``hvmcli interfaces list`` to check SR-IOV support status.

--- a/tools/hvmcli/logs.rst
+++ b/tools/hvmcli/logs.rst
@@ -1,0 +1,69 @@
+logs
+----
+
+View node, cluster, and Morpheus agent logs.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Command
+     - Description
+   * - ``node``
+     - View node syslog
+   * - ``cluster``
+     - View cluster/pcs logs
+   * - ``morpheus-agent``
+     - View Morpheus agent logs
+
+logs node
+`````````
+
+View the node's system log (syslog).
+
+.. code-block:: bash
+
+   sudo hvmcli logs node
+
+Stream logs in real-time:
+
+.. code-block:: bash
+
+   sudo hvmcli logs node --live
+
+Options:
+
+- ``--live`` — Stream logs continuously (similar to ``tail -f``)
+
+logs cluster
+````````````
+
+View cluster-related logs (Pacemaker/Corosync).
+
+.. code-block:: bash
+
+   sudo hvmcli logs cluster
+
+Stream logs in real-time:
+
+.. code-block:: bash
+
+   sudo hvmcli logs cluster --live
+
+logs morpheus-agent
+```````````````````
+
+View Morpheus agent logs.
+
+.. code-block:: bash
+
+   sudo hvmcli logs morpheus-agent
+
+Stream logs in real-time:
+
+.. code-block:: bash
+
+   sudo hvmcli logs morpheus-agent --live

--- a/tools/hvmcli/network.rst
+++ b/tools/hvmcli/network.rst
@@ -1,0 +1,53 @@
+network
+-------
+
+List virtual networks and run connectivity tests.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List configured libvirt networks
+   * - ``test``
+     - Run connectivity tests for gateways, DNS, and NTP
+
+network list
+````````````
+
+List all configured virtual networks (libvirt networks) on the host.
+
+.. code-block:: bash
+
+   sudo hvmcli network list
+
+.. code-block:: text
+
+   Name     State   Autostart  Persistent  Type   virtSwitch   Interface  Managed
+   -------  ------  ---------  ----------  -----  ----------   ---------  -------
+   default  active  yes        yes         other  -            -          no
+   vs0      active  yes        yes         bridge virtSwitch0  vs0-br     yes
+
+network test
+````````````
+
+Run connectivity tests to verify gateway, DNS, and NTP reachability.
+
+.. code-block:: bash
+
+   sudo hvmcli network test
+
+Test specific targets:
+
+.. code-block:: bash
+
+   sudo hvmcli network test --target 8.8.8.8 --target time.google.com
+
+Options:
+
+- ``--target <host>`` — Specific host or IP to test connectivity to (can be specified multiple times)

--- a/tools/hvmcli/node.rst
+++ b/tools/hvmcli/node.rst
@@ -1,0 +1,186 @@
+node
+----
+
+Manage the physical HVM host node configuration.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List node hardware, OS, and configuration summary
+   * - ``show-config``
+     - Show current NTP, DNS, and proxy configuration
+   * - ``configure``
+     - Configure node settings (NTP, DNS, hostname, proxy, locale, keymap, timezone, log-forwarding)
+   * - ``list-locales``
+     - List available system locales
+   * - ``list-keymaps``
+     - List available console keymaps
+   * - ``list-timezones``
+     - List available timezones
+   * - ``backup``
+     - Backup node configuration
+   * - ``restore``
+     - Restore node configuration from backup
+   * - ``reboot``
+     - Reboot the node
+   * - ``shutdown``
+     - Shut down the node
+   * - ``events``
+     - Query recent system journal events
+
+node list
+`````````
+
+Display a summary of the node's hardware, operating system, and basic configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli node list
+
+.. code-block:: text
+
+   Hostname            Vendor    Model  Serial        CPUs  CPU Model                       CPU MHz   Memory(GB)  OS                  Kernel             Uptime
+   ------------------  --------  -----  -----------   ----  ------------------------------  --------  ----------  ------------------  -----------------  ------------------------
+   hvm-node-01         HPE       DL360  MXQ123456     64    AMD EPYC 9334 32-Core           2695 MHz  512.0 GB    Ubuntu 24.04.4 LTS  6.8.0-134-generic  up 5 days, 12 hours
+
+node show-config
+````````````````
+
+Display the current NTP, DNS, proxy, and search domain configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli node show-config
+
+.. code-block:: text
+
+     NTP Servers         time.google.com, ntp.ubuntu.com
+     DNS Servers         10.227.1.91, 10.227.1.92
+     DNS Search Domains  example.com
+     HTTP Proxy          -
+
+node configure
+``````````````
+
+Configure various node settings. Each setting is specified with its own flag.
+
+**NTP Configuration:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --ntp "time.google.com,ntp.ubuntu.com"
+
+**DNS Configuration:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --dns "10.0.0.1,10.0.0.2" --dns-search "example.com"
+
+**Hostname:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --hostname hvm-node-01
+
+**HTTP Proxy:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --proxy "http://proxy.example.com:8080" --no-proxy "localhost,127.0.0.1"
+
+**Locale, Keymap, and Timezone:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --locale en_US.UTF-8
+   sudo hvmcli node configure --keymap us
+   sudo hvmcli node configure --timezone America/New_York
+
+**Log Forwarding:**
+
+.. code-block:: bash
+
+   sudo hvmcli node configure --log-forwarding "syslog://logserver.example.com:514"
+
+node list-locales
+`````````````````
+
+List all available system locales.
+
+.. code-block:: bash
+
+   sudo hvmcli node list-locales
+
+node list-keymaps
+`````````````````
+
+List all available console keymaps.
+
+.. code-block:: bash
+
+   sudo hvmcli node list-keymaps
+
+node list-timezones
+```````````````````
+
+List all available timezones.
+
+.. code-block:: bash
+
+   sudo hvmcli node list-timezones
+
+node backup
+```````````
+
+Create a backup of the node's current configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli node backup
+
+node restore
+````````````
+
+Restore node configuration from a previously created backup.
+
+.. code-block:: bash
+
+   sudo hvmcli node restore
+
+node reboot
+```````````
+
+Reboot the node.
+
+.. code-block:: bash
+
+   sudo hvmcli node reboot
+
+.. warning:: This will restart the host and all running VMs will be interrupted. Ensure VMs are properly shut down or migrated before rebooting.
+
+node shutdown
+`````````````
+
+Shut down the node.
+
+.. code-block:: bash
+
+   sudo hvmcli node shutdown
+
+.. warning:: This will power off the host. All running VMs will be forcefully stopped.
+
+node events
+```````````
+
+Query recent system journal events.
+
+.. code-block:: bash
+
+   sudo hvmcli node events

--- a/tools/hvmcli/security.rst
+++ b/tools/hvmcli/security.rst
@@ -1,0 +1,87 @@
+security
+--------
+
+Security compliance operations including FIPS 140 mode management.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``fips``
+     - Manage FIPS 140 mode (enable, disable, status)
+
+security fips
+`````````````
+
+Manage Federal Information Processing Standards (FIPS) 140 compliance mode.
+
+**Check FIPS status:**
+
+.. code-block:: bash
+
+   sudo hvmcli security fips status
+
+.. code-block:: text
+
+   FIPS Status
+   ───────────────────────────────────
+     Kernel FIPS mode:    ❌ DISABLED
+     FIPS kernel package: not installed
+     GRUB fips=1:         not configured
+
+     Packages:
+       ✗ ubuntu-fips — not-installed
+       ✗ linux-fips — not-installed
+       ✗ fips-initramfs — not-installed
+
+.. code-block:: bash
+
+   sudo hvmcli security fips status --json
+
+**Enable FIPS mode (dry run):**
+
+Preview what changes would be made without applying them:
+
+.. code-block:: bash
+
+   sudo hvmcli security fips enable --dry-run
+
+**Enable FIPS mode:**
+
+.. code-block:: bash
+
+   sudo hvmcli security fips enable --force
+   sudo hvmcli security fips enable --force --reboot
+
+Options:
+
+- ``--force`` — Skip confirmation prompts
+- ``--reboot`` — Automatically reboot the node after enabling FIPS (required for kernel-level FIPS activation)
+- ``--dry-run`` — Preview changes without applying
+
+**Disable FIPS mode (dry run):**
+
+.. code-block:: bash
+
+   sudo hvmcli security fips disable --dry-run
+
+**Disable FIPS mode:**
+
+.. code-block:: bash
+
+   sudo hvmcli security fips disable --force --reboot
+
+Options:
+
+- ``--force`` — Skip confirmation prompts
+- ``--reboot`` — Automatically reboot after disabling FIPS
+- ``--dry-run`` — Preview changes without applying
+
+.. important:: Enabling or disabling FIPS mode requires a reboot for the kernel FIPS mode to take effect. Use ``--reboot`` to handle this automatically, or plan a manual reboot.
+
+.. note:: FIPS 140 mode enforces the use of FIPS-validated cryptographic modules for all system-level encryption operations. This is required for compliance with certain government and regulatory standards.

--- a/tools/hvmcli/software.rst
+++ b/tools/hvmcli/software.rst
@@ -1,0 +1,106 @@
+software
+--------
+
+Inspect installed software packages and manage OS updates.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List installed versions for qemu, libvirt, kernel, and hvmcli
+   * - ``update``
+     - Manage package and OS updates
+
+software list
+`````````````
+
+Show installed versions of key HVM components.
+
+.. code-block:: bash
+
+   sudo hvmcli software list
+
+software update
+```````````````
+
+Manage OS and package updates with pre-checks, rollback support, and history tracking.
+
+**List available updates:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update list
+
+**Run pre-check before updating:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update precheck
+   sudo hvmcli software update precheck --interactive
+
+**Check pre-check status:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update precheck status
+
+**Perform OS update:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update os
+   sudo hvmcli software update os --force
+   sudo hvmcli software update os --interactive
+
+Options:
+
+- ``--force`` — Skip confirmation and proceed with update
+- ``--interactive`` — Run in interactive mode with progress display
+
+**Check update status:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update status
+
+**View update history:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update history
+   sudo hvmcli software update history --count 5
+   sudo hvmcli software update history --id 2026-04-07T12-15-25Z
+
+Options:
+
+- ``--count <n>`` — Limit to last N entries
+- ``--id <timestamp>`` — Show details for a specific update
+
+**Rollback an update:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update rollback --dry-run
+   sudo hvmcli software update rollback
+
+Options:
+
+- ``--dry-run`` — Preview what would be rolled back without making changes
+
+**Install a specific package:**
+
+.. code-block:: bash
+
+   sudo hvmcli software update package install --file /tmp/package.deb
+
+Options:
+
+- ``--file <path>`` — Path to the .deb package file to install
+
+.. important:: Always run ``precheck`` before performing an OS update. The pre-check validates that the host is in a safe state for updates (no running VMs, cluster quorum intact, sufficient disk space).

--- a/tools/hvmcli/storage.rst
+++ b/tools/hvmcli/storage.rst
@@ -1,0 +1,125 @@
+storage
+-------
+
+Manage storage pools, iSCSI targets, Fibre Channel HBAs, and multipath configuration.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List storage pools
+   * - ``iscsi``
+     - Manage iSCSI targets (configure, delete, list, multipath)
+   * - ``fc``
+     - Manage Fibre Channel HBAs (list, multipath)
+   * - ``multipath``
+     - Manage multipath configuration (status, validate, configure, apply)
+   * - ``rescan``
+     - Rescan iSCSI/FC storage for new LUNs
+
+storage list
+````````````
+
+List all storage pools configured on the host.
+
+.. code-block:: bash
+
+   sudo hvmcli storage list
+
+storage iscsi
+`````````````
+
+Manage iSCSI target connections.
+
+**List iSCSI sessions:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage iscsi --list
+
+**Show iSCSI multipath status:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage iscsi --multipath
+
+**Configure a new iSCSI target:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage iscsi configure --portal 10.0.0.1
+
+**Delete an iSCSI target:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage iscsi delete --portal 10.0.0.1
+
+Options:
+
+- ``--list`` — List current iSCSI sessions
+- ``--multipath`` — Show multipath status for iSCSI devices
+- ``--portal <ip>`` — iSCSI target portal IP address
+
+storage fc
+``````````
+
+Manage Fibre Channel HBA connections.
+
+**List Fibre Channel HBAs:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage fc --list
+
+**Show FC multipath status:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage fc --multipath
+
+storage multipath
+`````````````````
+
+Manage multipath I/O configuration for both iSCSI and FC storage.
+
+**Show multipath status:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage multipath status
+
+**Validate multipath configuration:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage multipath validate
+
+**Apply default multipath configuration:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage multipath configure-default
+
+**Force apply multipath configuration:**
+
+.. code-block:: bash
+
+   sudo hvmcli storage multipath apply --force
+
+storage rescan
+``````````````
+
+Rescan iSCSI and Fibre Channel storage to discover new LUNs.
+
+.. code-block:: bash
+
+   sudo hvmcli storage rescan
+
+.. tip:: Run ``storage rescan`` after provisioning new LUNs on your storage array to make them visible to the host.

--- a/tools/hvmcli/top.rst
+++ b/tools/hvmcli/top.rst
@@ -1,0 +1,119 @@
+top
+---
+
+Real-time host and VM resource monitoring. Similar to the Linux ``top`` command but focused on virtualization metrics.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``cpu``
+     - Per-VM CPU utilisation, vCPUs, and state
+   * - ``memory``
+     - Per-VM memory allocated, used, and balloon
+   * - ``network``
+     - Per-vNIC packet/byte rates and drops
+   * - ``disk``
+     - Per-block-device IOPS and throughput
+   * - ``hba``
+     - FC/iSCSI adapter performance
+   * - ``host``
+     - Host summary (uptime, load, VM count)
+
+top (default)
+`````````````
+
+Run the interactive top view showing an overview of all resources.
+
+.. code-block:: bash
+
+   sudo hvmcli top
+
+.. code-block:: bash
+
+   sudo hvmcli top --json
+
+top cpu
+```````
+
+Show per-VM CPU utilisation, vCPU count, and power state.
+
+.. code-block:: bash
+
+   sudo hvmcli top cpu --json
+
+Filter by VM name:
+
+.. code-block:: bash
+
+   sudo hvmcli top cpu --filter web-vm --json
+
+top memory
+``````````
+
+Show per-VM memory allocation, actual usage, and balloon driver status.
+
+.. code-block:: bash
+
+   sudo hvmcli top memory --json
+
+top network
+```````````
+
+Show per-vNIC packet rates, byte throughput, and drop counts.
+
+.. code-block:: bash
+
+   sudo hvmcli top network --json
+
+top disk
+````````
+
+Show per-block-device IOPS and throughput for VMs.
+
+.. code-block:: bash
+
+   sudo hvmcli top disk --json
+
+top hba
+```````
+
+Show Fibre Channel and iSCSI adapter performance metrics.
+
+.. code-block:: bash
+
+   sudo hvmcli top hba --json
+
+top host
+````````
+
+Show a host-level summary including uptime, load averages, and VM count.
+
+.. code-block:: bash
+
+   sudo hvmcli top host --json
+
+.. code-block:: json
+
+   {
+     "errorCode": 0,
+     "messages": "",
+     "data": {
+       "uptime": "5 days, 12 hours, 45 minutes",
+       "vmCount": 12,
+       "totalVcpus": 48,
+       "loadAvg1": 2.15,
+       "loadAvg5": 1.89,
+       "loadAvg15": 1.72
+     }
+   }
+
+Options (all subcommands):
+
+- ``--json`` — Output in JSON format
+- ``--filter <vm-name>`` — Filter results to a specific VM

--- a/tools/hvmcli/virtswitch.rst
+++ b/tools/hvmcli/virtswitch.rst
@@ -1,0 +1,256 @@
+virtswitch
+----------
+
+Manage Virtual Switches on the HVM host. Virtual Switches abstract host-level networking (bonds, bridges, VLANs) into a simple management model.
+
+.. danger:: Direct use of ``hvmcli virtswitch`` commands can disrupt host networking and cause loss of connectivity. It is **highly recommended** to manage Virtual Switches through the Morpheus UI (Infrastructure > Clusters > Network > Virtual Switches) instead. Only use these CLI commands when directed by HPE support or when the Morpheus UI is unavailable.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List managed Virtual Switch configurations
+   * - ``list-route``
+     - List Virtual Switch routes and default route mappings
+   * - ``create``
+     - Create a new Virtual Switch
+   * - ``import``
+     - Import an existing network interface into a managed Virtual Switch
+   * - ``edit``
+     - Edit Virtual Switch configuration
+   * - ``add-segment``
+     - Add a VLAN segment to an existing Virtual Switch
+   * - ``edit-segment``
+     - Edit a segment or manage static routes
+   * - ``delete-segment``
+     - Delete a VLAN segment from a Virtual Switch
+   * - ``delete``
+     - Delete a Virtual Switch and its associated metadata
+   * - ``rename``
+     - Rename a Virtual Switch (metadata only)
+   * - ``export``
+     - Export Virtual Switch config as YAML or JSON
+   * - ``show``
+     - Show detailed Virtual Switch view
+   * - ``status``
+     - Show real-time operational status
+
+virtswitch list
+```````````````
+
+List all managed Virtual Switches on the host.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch list
+
+Use ``--filter`` to show specific Virtual Switch types:
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch list --filter general
+   sudo hvmcli virtswitch list --filter data
+   sudo hvmcli virtswitch list --filter sdn
+
+virtswitch list-route
+`````````````````````
+
+List routes and default route mappings for managed Virtual Switches.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch list-route
+
+virtswitch create
+`````````````````
+
+Create a new Virtual Switch with specified uplinks and traffic configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch create \
+     --virtswitch-name virtSwitch0 \
+     --type general \
+     --uplink-name eth0 \
+     --traffic-type management \
+     --ip 10.0.0.10 \
+     --netmask 24 \
+     --gateway 10.0.0.1
+
+**Create with bonded uplinks:**
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch create \
+     --virtswitch-name virtSwitch0 \
+     --type general \
+     --uplink-name eth0,eth1 \
+     --uplink-mode active-backup
+
+Options:
+
+- ``--virtswitch-name <name>`` — Name for the Virtual Switch (max 12 characters)
+- ``--type <general|iscsi|sdn>`` — Virtual Switch type
+- ``--uplink-name <nic>[,<nic>]`` — Physical NIC(s) to use as uplinks
+- ``--uplink-mode <active-backup|802.3ad>`` — Bond mode when using two uplinks
+- ``--traffic-type <management|vm|data-nfs|live-migration|iscsi|sdn>`` — Traffic type for the segment
+- ``--ip <address>`` — IP address for the host interface
+- ``--netmask <prefix>`` — Subnet mask or prefix length
+- ``--gateway <address>`` — Default gateway
+- ``--mtu <1500|9000>`` — MTU size
+- ``--vlan-id <2-4094>`` — VLAN ID for tagged traffic
+
+virtswitch import
+`````````````````
+
+Import an existing network interface (e.g., a pre-configured bridge) into a managed Virtual Switch.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch import --interface br-mgmt
+
+This is used during cluster creation to adopt existing management bridges without disrupting connectivity.
+
+virtswitch edit
+```````````````
+
+Edit an existing Virtual Switch configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch edit --virtswitch-name virtSwitch0 --mtu 9000 --force
+
+Options:
+
+- ``--virtswitch-name <name>`` — Name of the Virtual Switch to edit (required)
+- ``--mtu <1500|9000>`` — New MTU value
+- ``--uplink-mode <active-backup|802.3ad>`` — Change bond mode
+- ``--force`` — Skip confirmation prompts
+
+virtswitch add-segment
+``````````````````````
+
+Add a VLAN segment to an existing general or iSCSI Virtual Switch.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch add-segment \
+     --virtswitch-name virtSwitch0 \
+     --vlan-id 100 \
+     --traffic-type data-nfs \
+     --ip 172.16.0.10 \
+     --netmask 24
+
+Options:
+
+- ``--virtswitch-name <name>`` — Target Virtual Switch (required)
+- ``--vlan-id <2-4094>`` — VLAN ID for the segment
+- ``--traffic-type <data-nfs|live-migration|iscsi|sdn>`` — Traffic type
+- ``--ip <address>`` — IP address for this segment
+- ``--netmask <prefix>`` — Subnet mask or prefix length
+- ``--gateway <address>`` — Gateway for this segment
+
+virtswitch edit-segment
+```````````````````````
+
+Edit a segment or manage static routes on an existing Virtual Switch.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch edit-segment \
+     --virtswitch-name virtSwitch0 \
+     --traffic-type data-nfs \
+     --ip 172.16.0.20 \
+     --force
+
+Options:
+
+- ``--virtswitch-name <name>`` — Target Virtual Switch (required)
+- ``--traffic-type <type>`` — Traffic type of the segment to edit (required)
+- ``--force`` — Skip confirmation prompts
+
+virtswitch delete-segment
+`````````````````````````
+
+Remove a VLAN segment from a Virtual Switch.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch delete-segment \
+     --virtswitch-name virtSwitch0 \
+     --traffic-type data-nfs
+
+Options:
+
+- ``--virtswitch-name <name>`` — Target Virtual Switch (required)
+- ``--traffic-type <type>`` — Traffic type of the segment to delete (required)
+
+virtswitch delete
+`````````````````
+
+Delete a Virtual Switch and all associated host networking configuration.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch delete --virtswitch-name virtSwitch0 --force
+
+Options:
+
+- ``--virtswitch-name <name>`` — Virtual Switch to delete (required)
+- ``--force`` — Skip confirmation prompts
+
+.. warning:: Deleting a Virtual Switch removes all associated bridges, bonds, and VLAN configurations from the host.
+
+virtswitch rename
+`````````````````
+
+Rename a Virtual Switch. This only updates metadata — no network changes are applied.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch rename --virtswitch-name virtSwitch0 --new-name mySwitch
+
+Options:
+
+- ``--virtswitch-name <name>`` — Current Virtual Switch name (required)
+- ``--new-name <name>`` — New name (max 12 characters, required)
+
+virtswitch export
+`````````````````
+
+Export a Virtual Switch configuration as YAML or JSON.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch export --virtswitch-name virtSwitch0 --format json
+   sudo hvmcli virtswitch export --virtswitch-name virtSwitch0 --format yaml
+
+Options:
+
+- ``--virtswitch-name <name>`` — Virtual Switch to export (required)
+- ``--format <yaml|json>`` — Output format (default: yaml)
+
+virtswitch show
+```````````````
+
+Show a detailed view of a Virtual Switch including segments, uplinks, and bridge information.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch show --virtswitch-name virtSwitch0
+
+virtswitch status
+`````````````````
+
+Show real-time operational status of Virtual Switches including link state and sync status.
+
+.. code-block:: bash
+
+   sudo hvmcli virtswitch status
+   sudo hvmcli virtswitch status --virtswitch-name virtSwitch0 --json

--- a/tools/hvmcli/vm.rst
+++ b/tools/hvmcli/vm.rst
@@ -1,0 +1,108 @@
+vm
+--
+
+Manage virtual machines on the HVM host.
+
+Commands
+````````
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Command
+     - Description
+   * - ``list``
+     - List VMs with name, power state, CPU, memory, and disk count
+   * - ``start``
+     - Start a virtual machine
+   * - ``stop``
+     - Stop a virtual machine (graceful or forced)
+   * - ``restart``
+     - Restart a virtual machine
+   * - ``reboot``
+     - Reboot a virtual machine
+
+vm list
+```````
+
+List all virtual machines on the host with their current status.
+
+.. code-block:: bash
+
+   sudo hvmcli vm list
+
+.. code-block:: text
+
+   VM Name       Power State  CPUs  Memory(GB)  Disks
+   ----------    -----------  ----  ----------  -----
+   web-server    running      4     8.0         2
+   db-server     running      8     32.0        4
+   test-vm       shut off     2     4.0         1
+
+Use ``--details`` for extended information:
+
+.. code-block:: bash
+
+   sudo hvmcli vm list --details
+
+vm start
+````````
+
+Start a stopped virtual machine.
+
+.. code-block:: bash
+
+   sudo hvmcli vm start --name my-vm
+
+Options:
+
+- ``--name <vm>`` — Name of the virtual machine to start (required)
+
+vm stop
+```````
+
+Stop a running virtual machine. By default performs a graceful ACPI shutdown.
+
+.. code-block:: bash
+
+   sudo hvmcli vm stop --name my-vm
+
+Force an immediate power-off (equivalent to pulling the power cord):
+
+.. code-block:: bash
+
+   sudo hvmcli vm stop --name my-vm --force
+
+Options:
+
+- ``--name <vm>`` — Name of the virtual machine to stop (required)
+- ``--force`` — Force immediate power-off without graceful shutdown
+
+.. warning:: Using ``--force`` may cause data loss or filesystem corruption if the guest OS has pending writes.
+
+vm restart
+``````````
+
+Restart a virtual machine (stop then start).
+
+.. code-block:: bash
+
+   sudo hvmcli vm restart --name my-vm
+
+Options:
+
+- ``--name <vm>`` — Name of the virtual machine to restart (required)
+
+vm reboot
+`````````
+
+Send a reboot signal to the virtual machine's guest OS.
+
+.. code-block:: bash
+
+   sudo hvmcli vm reboot --name my-vm
+
+Options:
+
+- ``--name <vm>`` — Name of the virtual machine to reboot (required)

--- a/tools/tools.rst
+++ b/tools/tools.rst
@@ -15,3 +15,4 @@ Tools
   catalog_item_types.rst
   migrations/migrations.rst
   ai/ai.rst
+  hvmcli/hvmcli.rst


### PR DESCRIPTION
## Summary

Adds comprehensive CLI reference documentation for `hvmcli` under **Tools > HVMCLI**. Each namespace is documented on its own page with commands, options, and usage examples verified against a live HVM host.

## Structure

```
tools/hvmcli/
├── hvmcli.rst          (index + toctree)
├── getting_started.rst (global options, JSON format, namespace overview)
├── vm.rst              (list, start, stop, restart, reboot)
├── node.rst            (list, show-config, configure, backup, restore, reboot, shutdown)
├── interfaces.rst      (list, vf - SR-IOV management)
├── virtswitch.rst      (create, edit, delete, import, segments, export, status)
├── network.rst         (list, test)
├── storage.rst         (list, iscsi, fc, multipath, rescan)
├── cluster.rst         (status, nodes)
├── hardware.rst        (cpu, memory, pci, bootvolume, ipmi)
├── software.rst        (list, update - precheck/os/history/rollback/package)
├── logs.rst            (node, cluster, morpheus-agent)
├── health.rst          (check, watch)
├── top.rst             (cpu, memory, network, disk, hba, host)
├── security.rst        (fips - enable/disable/status)
└── deploy.rst          (manager, worker - VME deployment)
```

## Key Points

- Follows the same format as the existing Morpheus CLI docs (screenshot reference provided)
- Each page has: command table, syntax, options, and real examples
- Virtual Switch namespace includes a danger notice recommending Morpheus UI usage
- Covers all 16 namespaces available in hvmcli 1.0.0
- Added to the Tools toctree alongside existing tools (Cypher, Terraform, etc.)